### PR TITLE
Changed the image build and its dir structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,16 @@ FROM ffig/ffig-base
 MAINTAINER support@ffig.org
 
 # Install flask
-RUN pip install --upgrade pip && \
+RUN pip2 install --upgrade pip && \
     pip2 install flask && \
     pip3 install --upgrade pip && \
     pip3 install flask
 
 # Install the ffig codebase. Use `cd` here to avoid several WORKDIR layers.
-RUN cd /home/ffig && \
-    curl -O https://github.com/FFIG/ffig/archive/master.zip && \
-    unzip ffig-master.zip && \
-    rm -f ffig-master.zip
+RUN cd /home && \
+    curl -LOk https://github.com/FFIG/ffig/archive/master.zip && \
+    unzip master.zip && \
+    rm -f master.zip
 
 # Copy in the content of this repository
 COPY . /home/flask/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ RUN pip install --upgrade pip && \
     pip3 install flask
 
 # Install the ffig codebase. Use `cd` here to avoid several WORKDIR layers.
-ADD https://github.com/FFIG/ffig/archive/master.zip /home/
-RUN unzip home/master.zip -d home/ && \
-    rm -f home/master.zip
+RUN cd /home/ffig && \
+    curl -O https://github.com/FFIG/ffig/archive/master.zip && \
+    unzip ffig-master.zip && \
+    rm -f ffig-master.zip
 
 # Copy in the content of this repository
 COPY . /home/flask/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,20 +8,17 @@ MAINTAINER support@ffig.org
 
 # Install flask
 RUN pip install --upgrade pip && \
-    pip install flask && \
+    pip2 install flask && \
     pip3 install --upgrade pip && \
     pip3 install flask
 
 # Install the ffig codebase. Use `cd` here to avoid several WORKDIR layers.
-RUN cd /home/ffig && \
-    curl -O https://github.com/FFIG/ffig/archive/master.zip && \
-    unzip ffig-master.zip && \
-    rm -f ffig-master.zip
+ADD https://github.com/FFIG/ffig/archive/master.zip /home/
+RUN unzip home/master.zip -d home/ && \
+    rm -f home/master.zip
 
 # Copy in the content of this repository
-COPY . /home/ffig/flask
+COPY . /home/flask/
 
-WORKDIR /home/ffig/flask
+WORKDIR /home/flask/
 
-# Default flask port
-EXPOSE 5000

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-At the moment, we are looking for a simple REST API with 1 endpoint. 
+At the moment, we are looking for a simple REST API with 1 endpoint. The endpoint takes POST requests with header files and type of binding you want to generate.
 
-Implemented as a flask-app.
+Implemented as a flask-app inside a Docker container with port binding to host. 
+
+To build and run the docker image, run
+
+```
+docker build -t ffig/web-base:latest .
+docker run -p 5000:5000 -it ffig/web-base:latest /bin/bash
+```


### PR DESCRIPTION
Removed one extra layer of directories.
Before:
/home/ffig/ffig-master
/home/ffig/flask

Now:
/home/ffig-master/
/home/flask

pip2 install to guarantee installing flask for py2

remove RUN .. curl, because curl wasn't installed - docker build was breaking
Instead ADD from the github link

Won't expose anymore - we need port binding in
docker run -p 5000:5000, not exposing portts